### PR TITLE
OSC Transmission Listener

### DIFF
--- a/src/main/java/heronarts/lx/osc/LXOscEngine.java
+++ b/src/main/java/heronarts/lx/osc/LXOscEngine.java
@@ -73,6 +73,10 @@ public class LXOscEngine extends LXComponent {
     public void outputRemoved(LXOscEngine osc, LXOscConnection.Output output);
   }
 
+  public interface TransmissionListener {
+    public void oscMessageTransmitted(OscPacket packet);
+  }
+
   public enum IOState {
     STOPPED,
     BINDING,
@@ -162,6 +166,9 @@ public class LXOscEngine extends LXComponent {
 
   private final List<LXOscListener> listeners =
     new ArrayList<LXOscListener>();
+
+  private final List<TransmissionListener> transmissionListeners =
+    new ArrayList<TransmissionListener>();
 
   private final LXOscQueryServer oscQueryServer;
   private final Zeroconf zeroconf;
@@ -317,6 +324,27 @@ public class LXOscEngine extends LXComponent {
     return this;
   }
 
+  public LXOscEngine addTransmissionListener(TransmissionListener listener) {
+    Objects.requireNonNull("May not add null TransmissionListener");
+    if (this.transmissionListeners.contains(listener)) {
+      throw new IllegalStateException(
+        "Cannot add duplicate LXOscEngine.TransmissionListener: "
+          + listener);
+    }
+    this.transmissionListeners.add(listener);
+    return this;
+  }
+
+  public LXOscEngine removeTransmissionListener(TransmissionListener listener) {
+    if (!this.transmissionListeners.contains(listener)) {
+      throw new IllegalStateException(
+        "Cannot remove non-existent LXOscEngine.TransmissionListener: "
+          + listener);
+    }
+    this.transmissionListeners.remove(listener);
+    return this;
+  }
+
   public LXOscEngine sendMessage(String path, int value) {
     if (this.engineTransmitter != null) {
       this.engineTransmitter.sendMessage(path, value);
@@ -468,6 +496,17 @@ public class LXOscEngine extends LXComponent {
       if (this.activity != null) {
         this.activity.trigger();
       }
+      
+      // Notify transmission listeners
+      for (TransmissionListener listener : transmissionListeners) {
+        try {
+          listener.oscMessageTransmitted(packet);
+        } catch (Exception e) {
+          // Log error but continue with transmission
+          error(e, "Error in TransmissionListener: " + e.getMessage());
+        }
+      }
+      
       this.buffer.rewind();
       packet.serialize(this.buffer);
       this.packet.setLength(this.buffer.position());


### PR DESCRIPTION
Initial Approach, just posting here for the sake of comparison.

Main problem is that since the expectation is that a `TransmissionListener` would use `lx.engine.osc.sendMessage()`, there's no way to ensure implementors won't hit an infinite loop.

Rough Usage:

```java
private class OscRemapperTransmissionListener implements LXOscEngine.TransmissionListener {
    @Override
    public void oscMessageTransmitted(OscPacket packet) {
      try {
        // Check if this is an OscMessage that we should remap
        if (packet instanceof OscMessage) {
          OscMessage message = (OscMessage) packet;
          String originalAddress = message.getAddressPattern().getValue();
		  
          // Get the remapped addresses (can be multiple destinations)
          List<String> remappedAddresses = remote.remapAddress(originalAddress);
        
           // Send the remapped message to each destination
           for (String remappedAddress : remappedAddresses) {
             try {
                lx.engine.osc.sendMessage(remappedAddress, value);
             } catch (Exception e) {
                LOG.error(e, "Failed to send remapped message to " + remappedAddress + " for " + remote.getName());
             }
           }
        }
      } catch (Exception e) {
        LOG.error(e, "Error processing transmitted OSC message");
      }
    }

```